### PR TITLE
removed redundant procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: gunicorn app:app


### PR DESCRIPTION
This pull request removes the web process definition from the `Procfile`, which means the application will no longer be started using `gunicorn` via the Procfile (not needed since application is deployed via **Vercel** which requires `vercel.json`). This is closes issue #157 .